### PR TITLE
chore: remove un-needed entries in ESLint config

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,3 @@
 {
-  "extends": ["next", "next/core-web-vitals", "plugin:prettier/recommended"],
-  "plugins": ["prettier"],
-  "rules": {
-    "prettier/prettier": "error"
-  }
+  "extends": ["next", "next/core-web-vitals", "plugin:prettier/recommended"]
 }


### PR DESCRIPTION
Não tem necessidade delas estarem nesse arquivo de config, a configuração `recommended` do `eslint-plugin-prettier` já faz isso.

https://github.com/prettier/eslint-plugin-prettier/blob/76bd45ece6d56eb52f75db6b4a1efdd2efb56392/eslint-plugin-prettier.js#L90